### PR TITLE
Update startService.ps1

### DIFF
--- a/Tasks/StartWindowsServices/startService.ps1
+++ b/Tasks/StartWindowsServices/startService.ps1
@@ -74,7 +74,7 @@ try {
 
 			}
 			else{
-				New-Service -Name "$ServiceName" -BinaryPathName "'$ServiceFolder'" -DisplayName "$ServiceName" -Credential $credential -StartupType $startupType
+				New-Service -Name "$ServiceName" -BinaryPathName "$ServiceFolder" -DisplayName "$ServiceName" -Credential $credential -StartupType $startupType
 			}
 			
 			


### PR DESCRIPTION
' character on the BinaryPathName is causing the windows service not to run.
As a workaround, I've edited the ImagePath directly using Regedit, but this would probably be the best fix for the problem.